### PR TITLE
SQL filetype recognizable information inside repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sql linguist-detectable=true
+*.sql linguist-language=sql


### PR DESCRIPTION
Dear Luis Rocha
I would like to suggest add .gitattributes file indicating SQL as recognizable information inside git repository.

Here I demonstrate distinction between them, already applied on my fork repository:

![Without .gitattribute, mostly recognizable as C#](https://user-images.githubusercontent.com/23739031/210679961-369f0508-7739-4ecb-8e5d-51298515b267.png)

![With .gitattributes, mostly recognizable as SQL](https://user-images.githubusercontent.com/23739031/210680053-51ee1d6e-07bb-4506-ba7c-90595b73efdc.png)

Best regards!


